### PR TITLE
don't require old TLS versions

### DIFF
--- a/checker/hostname.go
+++ b/checker/hostname.go
@@ -255,8 +255,6 @@ func checkTLSVersion(h HostnameResult) CheckResult {
 	result := CheckResult{Name: "version"}
 	versions := map[uint16]bool{
 		tls.VersionSSL30: false,
-		tls.VersionTLS10: true,
-		tls.VersionTLS11: true,
 		tls.VersionTLS12: true,
 	}
 	for version, shouldWork := range versions {


### PR DESCRIPTION
this should prevent the checker from requiring older TLS versions.

if this is merged in, to get this change propagated up to the site, make sure to rebuild the `scanner` image on DockerHub in addition to re-deploying the site.